### PR TITLE
ブリーディング関連のパラメータを上方修正

### DIFF
--- a/dynamicconfig.ini
+++ b/dynamicconfig.ini
@@ -1,9 +1,8 @@
 TamingSpeedMultiplier=3.0
 HarvestAmountMultiplier=3.0
 XPMultiplier=3.0
-MatingIntervalMultiplier=0.05
-BabyMatureSpeedMultiplier=200.0
-EggHatchSpeedMultiplier=200.0
-BabyCuddleIntervalMultiplier=0.01
-BabyImprintAmountMultiplier=3.0
+MatingIntervalMultiplier=0.1
+BabyMatureSpeedMultiplier=100
+EggHatchSpeedMultiplier=100
+BabyCuddleIntervalMultiplier=0.0172
 HexagonRewardMultiplier=1.5


### PR DESCRIPTION
## 概要

現在メキシコに手動設定されている内容に追従させた。

ただし、この変更を含むDynamicConfigをロードしたとしても、手動設定されたメキシコとは完全には一致しない。詳しくは補遺を参照。

## 変更内容

* 「1回の交配」から「次の交配」が可能になるまでのクールタイムを1/10に
* 卵の孵化にかかるまでの時間/出産にかかる時間を1/10に
* 子供が成長しきるまでの時間を1/10に
* 成長速度を速めた分、子供の「お世話」が必要になる間隔を短くなるように調整

### 軽微な変更

* ファイル末尾に改行がなかったため、改行をつけた

## 補遺1

[公式ドキュメント](https://ark.fandom.com/wiki/Server_configuration) より、DynamicConfigによって設定することのできるパラメータは制限されている:

> currently only the following options are supported to be adjusted dynamically: `TamingSpeedMultiplier` , `HarvestAmountMultiplier` , `XPMultiplier` , `MatingIntervalMultiplier` , `BabyMatureSpeedMultiplier` , `EggHatchSpeedMultiplier` , `BabyFoodConsumptionSpeedMultiplier` , `CropGrowthSpeedMultiplier` , `MatingSpeedMultiplier` , `BabyCuddleIntervalMultiplier`, `BabyImprintAmountMultiplier` , `CustomRecipeEffectivenessMultiplier` , `TributeItemExpirationSeconds` , `TributeDinoExpirationSeconds` , `EnableFullDump` , `GUseServerNetSpeedCheck` , `bUseAlarmNotifications` , `HexagonRewardMultiplier` and `NPCReplacements` .

実際のメキシコでは、成長速度を速めたことに対応して `BabyImprintingStatScaleMultiplier` と `BabyCuddleLoseImprintQualitySpeedMultiplier` を変更し「刷り込みボーナス量の上昇」と「刷り込み失敗時のボーナス減少速度の低下」を行っているが、これらのパラメータはDynamicConfigによる動的変更対応パラメータには含まれていない。

そのため、この変更を含むDynamicConfigをロードしたとしても、手動設定されたメキシコとは完全には一致しない。

## 補遺2

補遺1より、メキシコの設定はDynamicConfigのサポート範囲を超えているため、これの使用を中止し、 `Game.ini` 自体をGit管理したほうが望ましいと思料する。